### PR TITLE
handle relative paths (closes #32)

### DIFF
--- a/src/locate.jl
+++ b/src/locate.jl
@@ -22,6 +22,14 @@ function source_paths(mod, file)
     mfiles = joinpath.(mdata.basedir, mdata.files)
     
     file = expanduser(file)
+    if isfile(file)
+        # This was something point to a real file that exists at a location
+        # not just filename **somewhere**
+        # It may have been a relative path, if so that is hard to deal with
+        # So we will make it absolute.
+        file=abspath(file)
+    end
+    
     if !isabspath(file)
         # We do not need it to be absolute
         # But we do want it to start with a "/" if it isn't
@@ -30,7 +38,6 @@ function source_paths(mod, file)
         file = "/" * file
     end
     matched_inds = map(mfile->endswith(mfile, file), mfiles)
-     
     return mfiles[matched_inds]
 end
 
@@ -61,8 +68,9 @@ function containing_methods(mod, file, linenum)
     # only matches to
     # statement within the functions body, not from the line it is "declared"
     # or any intervening whitespace. It also doesn't match to the `end` line.
-    
-    return map(sigt2meth, sigs)
+
+    ret = map(sigt2meth, sigs)
+    return ret
 end
 
 function containing_methods(file, linenum)

--- a/test/test_locate.jl
+++ b/test/test_locate.jl
@@ -30,19 +30,18 @@ end
 
 @testset "containing_methods" begin
     # BADTEST: This is actually tied to line numbers in the source code
-    meth = containing_methods(MagneticReadHead, "src/locate.jl", 56)
-    for ln in (55, 56, 57)
+    LINENUM = 66
+    meth = containing_methods(MagneticReadHead, "src/locate.jl", LINENUM)
+    for ln in LINENUM .+ [-1, 0, 1]
         @test meth == containing_methods(MagneticReadHead, "src/locate.jl", ln)
         @test meth == containing_methods(MagneticReadHead, "locate.jl", ln)
         @test meth == containing_methods("locate.jl", ln)
-        @test_broken meth ==
-            containing_methods(MagneticReadHead, "../src/locate.jl", ln)
-        cd(@__DIR__) do
-            @test meth == containing_methods(
-                MagneticReadHead,
-                realpath("../src/locate.jl"),
-                ln
-            )
+        cd(@__DIR__) do  # Be in this directory, no matter where rrunning tests
+            @test meth ==  # Absolute path
+                containing_methods(MagneticReadHead, abspath("../src/locate.jl"),ln)
+        
+            @test meth ==  # Relative path
+                containing_methods(MagneticReadHead, "../src/locate.jl", ln)
         end
     end
 end

--- a/test/test_locate.jl
+++ b/test/test_locate.jl
@@ -36,7 +36,7 @@ end
         @test meth == containing_methods(MagneticReadHead, "src/locate.jl", ln)
         @test meth == containing_methods(MagneticReadHead, "locate.jl", ln)
         @test meth == containing_methods("locate.jl", ln)
-        cd(@__DIR__) do  # Be in this directory, no matter where rrunning tests
+        cd(@__DIR__) do  # Be in this directory, no matter where running tests
             @test meth ==  # Absolute path
                 containing_methods(MagneticReadHead, abspath("../src/locate.jl"),ln)
         


### PR DESCRIPTION
Closes #32 

This way this works is if the path points to something that actually exists,
then we lock in on that,
otherwise we fall back to the old "correct filename as something we have loaded" behavour.