### PR TITLE
Swap in LittleDict

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,8 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [compat]
 CodeTracking = "0.4.0"
-Revise = "2"
 OrderedCollections = "1.1"
+Revise = "2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 [compat]
 CodeTracking = "0.4.0"
 Revise = "2"
-# Revise 1.1 works, except for setting breakpoints on files outside of packages
+OrderedCollections = "1.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/core_control.jl
+++ b/src/core_control.jl
@@ -23,7 +23,7 @@ parent_stepping_mode(::StepOut) = StepNext()   # This is what they want
 
 
 mutable struct HandEvalMeta
-    variables::OrderedDict{Symbol, Any}
+    variables::LittleDict{Symbol, Any}
     eval_module::Module
     stepping_mode::SteppingMode
     breakpoint_rules::BreakpointRules
@@ -34,7 +34,7 @@ const GLOBAL_BREAKPOINT_RULES = BreakpointRules()
 
 function HandEvalMeta(eval_module, stepping_mode)
     return HandEvalMeta(
-        OrderedDict{Symbol,Any}(),
+        LittleDict{Symbol,Any}(),
         eval_module,
         stepping_mode,
         GLOBAL_BREAKPOINT_RULES
@@ -55,7 +55,6 @@ function Cassette.overdub(ctx::HandEvalCtx, f, args...)
     # This is basically the epicenter of all the logic
     # We control the flow of stepping modes
     # and which methods are instrumented or not.
-    @debug "overdubbing" f args
     method = methodof(f, args...)
     should_recurse =
         ctx.metadata.stepping_mode isa StepIn ||

--- a/src/core_control.jl
+++ b/src/core_control.jl
@@ -51,7 +51,7 @@ function Cassette.overdub(::typeof(HandEvalCtx()), args...)
 end
 
 
-function Cassette.overdub(ctx::HandEvalCtx, f, args...)
+function Cassette.overdub(ctx::HandEvalCtx, @nospecialize(f), @nospecialize(args...))
     # This is basically the epicenter of all the logic
     # We control the flow of stepping modes
     # and which methods are instrumented or not.

--- a/src/method_utils.jl
+++ b/src/method_utils.jl
@@ -4,7 +4,7 @@ functiontypeof(m::Method) = parameter_typeof(m.sig)[1]
 parameter_typeof(sig::UnionAll) = parameter_typeof(sig.body)
 parameter_typeof(sig::DataType) = sig.parameters
 
-function methodof(f, args...)
+function methodof(@nospecialize(f), @nospecialize(args...))
     try
         @which(f(args...))
     catch


### PR DESCRIPTION
This is why I made `LittleDict`,
it gives a small speedup
more would be possible I think by using a Tuple of keys declared at the start using to `slotnames`.

That would mean leaving the variables field of the metadata blank,
then writing some CodeIR to fill it.
Which would be annoying to do.

And right now not worth it, since current profiling shows actually the majority of time is being spent on type inference...