### PR TITLE
Stop looking up the methods at compile time. For much speed.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 CodeTracking = "0.4.0"
 OrderedCollections = "1.1"
 Revise = "2"
+Cassette = "0.2.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Within this you can read (and write) variables,
 
  - `set_breakpoint!([function|method])`: Set a breakpoint on call to the argument
  - `set_breakpoint!(filename, line number)`: Set a breakpoint on the given line in the given function
- - `set_nodebug!([function|method|module])`: Disable debugging in the given function/method/module
-    - Not having debugging enabled for modules that are not between you and your breakpoints massively speeds up the running of your program.
+ - `set_nodebug!([function|module])`: Disable debugging in the given function/module
+    - Not having debugging enabled for modules/functions you do not need to debug massively speeds up the running of your program.
+    - However, debugging is fully disabled for those modules/functions, so if those functions would then call functions you do want to debug (say by using `map`) then that will also not be caught by the debugger.
  - `list_breakpoints()`, `list_nodebugs()`: list all the breakpoints/nodebugs
  - `rm_breakpoint!(arg...)`, `rm_nodebug!(args...)`: remove breakpoints/nodebugs. Takes same arguments as `set_...`.
  - `clear_breakpoints!()`, `clear_nodebugs!()`: remove all breakpoints/nodebugs.

--- a/src/MagneticReadHead.jl
+++ b/src/MagneticReadHead.jl
@@ -9,7 +9,7 @@ using CodeTracking
 # We don't use Revise, but if it isn't loaded CodeTracking has issues
 using Revise: Revise
 
-export @iron_debug 
+export @iron_debug
 
 include("utils.jl")
 include("method_utils.jl")

--- a/src/breakpoint_rules.jl
+++ b/src/breakpoint_rules.jl
@@ -8,15 +8,19 @@ Rule(v) = Rule(v, 0)
 ##############################################################################
 # instrumenting rules
 match(rule::Rule{Method}, method::Method) = method == rule.v
-match(rule::Rule{Method}, da::DispatchAttempt) = accepts(rule.v, da)
+match(rule::Rule{Method}, f::F) where F = functiontypeof(rule.v) <: F
 
-match(rule::Rule{Module}, method) = moduleof(method) == rule.v
-function match(rule::Rule{F}, method) where F
-    # This one is for functions
+match(rule::Rule{Module}, method::Method) = moduleof(method) == rule.v
+match(rule::Rule{Module}, ::F) where F = F.name.module == rule.v
+
+# function
+match(rule::Rule{F}, ::G) where {F,G} = false
+match(rule::Rule{F}, ::F) where F = true
+function match(rule::Rule{F}, method::Method) where F
     return functiontypeof(method) <: F
 end
 
-#breakon rules
+# For breakpoints
 function match(rule::Rule, method, statement_ind)
     return match(rule, method) && rule.statement_ind == statement_ind
 end
@@ -39,10 +43,10 @@ BreakpointRules() = BreakpointRules(Rule[], Rule[])
 
 
 """
-    should_instrument(rules, method)
+    should_instrument(rules, method|function)
 
-Returns true if according to the rules, this method should be instrumented
-with potential breakpoints.
+Returns true if according to the rules, the specified
+method or function should be instrumented with potential breakpoints.
 The default is to instrument everything.
 """
 function should_instrument(rules::BreakpointRules, method)

--- a/src/breakpoint_rules.jl
+++ b/src/breakpoint_rules.jl
@@ -7,7 +7,9 @@ Rule(v) = Rule(v, 0)
 
 ##############################################################################
 # instrumenting rules
-match(rule::Rule{Method}, method) = method == rule.v
+match(rule::Rule{Method}, method::Method) = method == rule.v
+match(rule::Rule{Method}, da::DispatchAttempt) = accepts(rule.v, da)
+
 match(rule::Rule{Module}, method) = moduleof(method) == rule.v
 function match(rule::Rule{F}, method) where F
     # This one is for functions

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -27,7 +27,7 @@ end
 
 function set_nodebug!(the_rules::BreakpointRules, arg::T) where T
     T !== Method || throw(ArgumentError("Disabling instrumentation per method, is not supported."))
-    return push!(the_rules.breakon_rules, Rule(arg))
+    return push!(the_rules.no_instrument_rules, Rule(arg))
 end
 
 for (name, list) in ((:breakpoint, :breakon_rules), (:nodebug, :no_instrument_rules))

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -21,14 +21,20 @@ rules(args...) = (Rule(args...),)  # default to just constructing a Rule
 
 #TODO: think hard about API, eg maybe `set!(Breakpoint(foo,1))` might be nicest
 
+function set_breakpoint!(the_rules::BreakpointRules, args...)
+    return append!(the_rules.breakon_rules, rules(args...))
+end
+
+function set_nodebug!(the_rules::BreakpointRules, arg::T) where T
+    T !== Method || throw(ArgumentError("Disabling instrumentation per method, is not supported."))
+    return push!(the_rules.breakon_rules, Rule(arg))
+end
+
 for (name, list) in ((:breakpoint, :breakon_rules), (:nodebug, :no_instrument_rules))
     set! = Symbol(:set_, name, :!)
     @eval export $(set!)
     @eval $(set!)(args...) = $(set!)(GLOBAL_BREAKPOINT_RULES, args...)
-    @eval function $(set!)(the_rules::BreakpointRules, args...)
-        return append!(the_rules.$list, rules(args...))
-    end
-
+    # actual set definitions are above
     rm! = Symbol(:rm_, name, :!)
     @eval export $(rm!)
     @eval $(rm!)(args...) = $(rm!)(GLOBAL_BREAKPOINT_RULES, args...)

--- a/src/core_control.jl
+++ b/src/core_control.jl
@@ -55,10 +55,9 @@ function Cassette.overdub(ctx::HandEvalCtx, @nospecialize(f), @nospecialize(args
     # This is basically the epicenter of all the logic
     # We control the flow of stepping modes
     # and which methods are instrumented or not.
-    method = methodof(f, args...)
     should_recurse =
         ctx.metadata.stepping_mode isa StepIn ||
-        should_instrument(ctx.metadata.breakpoint_rules, method)
+        should_instrument(ctx.metadata.breakpoint_rules, DispatchAttempt(f, args))
 
     if should_recurse
         if Cassette.canrecurse(ctx, f, args...)
@@ -69,7 +68,8 @@ function Cassette.overdub(ctx::HandEvalCtx, @nospecialize(f), @nospecialize(args
                 ctx.metadata.stepping_mode = parent_stepping_mode(_ctx)
             end
         else
-            @warn "Not able to enter into method." f method
+            @assert f isa Core.Builtin
+            #@warn "Not able to enter into method" f args
             return Cassette.fallback(ctx, f, args...)
         end
     else  # !should_recurse

--- a/src/core_control.jl
+++ b/src/core_control.jl
@@ -51,13 +51,13 @@ function Cassette.overdub(::typeof(HandEvalCtx()), args...)
 end
 
 
-function Cassette.overdub(ctx::HandEvalCtx, @nospecialize(f), @nospecialize(args...))
+function Cassette.overdub(ctx::HandEvalCtx, f, @nospecialize(args...))
     # This is basically the epicenter of all the logic
     # We control the flow of stepping modes
     # and which methods are instrumented or not.
     should_recurse =
         ctx.metadata.stepping_mode isa StepIn ||
-        should_instrument(ctx.metadata.breakpoint_rules, DispatchAttempt(f, args))
+        should_instrument(ctx.metadata.breakpoint_rules, f)
 
     if should_recurse
         if Cassette.canrecurse(ctx, f, args...)

--- a/src/method_utils.jl
+++ b/src/method_utils.jl
@@ -1,22 +1,44 @@
-moduleof(m::Method) = m.module
+"""
+    moduleof
+
+Returns the module associated with a method.
+Note: this is not the module where it was defined (m.module)
+but rather the module for which it's function was defined.
+"""
+moduleof(m::Method) = functiontypeof(m).name.module
 
 functiontypeof(m::Method) = parameter_typeof(m.sig)[1]
 parameter_typeof(sig::UnionAll) = parameter_typeof(sig.body)
 parameter_typeof(sig::DataType) = sig.parameters
 
-function methodof(@nospecialize(f), @nospecialize(args...))
-    try
-        @which(f(args...))
-    catch
-        @warn "Determining methods failed" f arg_types=typeof.(args)
-        rethrow()
-    end
+"""
+    DispatchAttempt
+This is a lightweight type that represents a attemopt to dispatch against a method.
+It has two type params, `F` the function type,
+and `A` a tuple type of arguments.
+"""
+struct DispatchAttempt{F,A}
+    f::F
+    args::A
 end
 
-methodof(::Core.Builtin, args...) = nothing  # No methods for `Builtin`s
+"""
+    _typeof
+Like `typeof` but when applied to `DataType`s, returns `Type{T}`, rather than `DataType`
+"""
+_typeof(x)=typeof(x)
+_typeof(::Type{T}) where T = Type{T}
 
-#TODO: Methods are actually pretty slow to construct. 1-2μs and 8-15 allocations
-# when we construct them ourself we are only really using them has a container for
-# function, args types and module.
-# We could define out own `LightMethod`, which exposes also overloads the above
-# functions, while still keeping them working on real methods. And then just use that
+"""
+    accepts(meth::Method, ::DispatchAttempt{F,A}) where {F,A}
+It can be compared against a `Method` to see if that method would
+accept this dispatch.
+It does not check if that is the highest priority method that would accept this dispatch
+"""
+function accepts(meth::Method, da::DispatchAttempt)
+    dispatch_sig = Tuple{_typeof(da.f), map(_typeof, da.args)...}
+    return dispatch_sig <: meth.sig
+end
+
+# Builtin's do not have methods
+accepts(::Method, ::DispatchAttempt{<:Core.Builtin}) = false

--- a/src/method_utils.jl
+++ b/src/method_utils.jl
@@ -9,37 +9,3 @@ moduleof(m) = functiontypeof(m).name.module
 functiontypeof(m::Method) = parameter_typeof(m.sig)[1]
 parameter_typeof(sig::UnionAll) = parameter_typeof(sig.body)
 parameter_typeof(sig::DataType) = sig.parameters
-
-"""
-    DispatchAttempt
-This is a lightweight type that represents a attemopt to dispatch against a method.
-It has two type params, `F` the function type,
-and `A` a tuple type of arguments.
-"""
-struct DispatchAttempt{F,A}
-    f::F
-    args::A
-end
-
-"""
-    _typeof
-Like `typeof` but when applied to `DataType`s, returns `Type{T}`, rather than `DataType`
-"""
-_typeof(x)=typeof(x)
-_typeof(::Type{T}) where T = Type{T}
-
-"""
-    accepts(meth::Method, ::DispatchAttempt{F,A}) where {F,A}
-It can be compared against a `Method` to see if that method would
-accept this dispatch.
-It does not check if that is the highest priority method that would accept this dispatch
-"""
-function accepts(meth::Method, da::DispatchAttempt)
-    dispatch_sig = Tuple{_typeof(da.f), map(_typeof, da.args)...}
-    return dispatch_sig <: meth.sig
-end
-
-# Builtin's do not have methods
-accepts(::Method, ::DispatchAttempt{<:Core.Builtin}) = false
-
-functiontypeof(m::DispatchAttempt{F}) where F = F

--- a/src/method_utils.jl
+++ b/src/method_utils.jl
@@ -5,7 +5,10 @@ Returns the module associated with a method.
 Note: this is not the module where it was defined (m.module)
 but rather the module for which it's function was defined.
 """
-moduleof(m) = functiontypeof(m).name.module
+moduleof(m::Method) = moduleof(functiontypeof(m))
+moduleof(sig::DataType) = sig.name.module
+moduleof(sig::UnionAll) = moduleof(sig.body)
+
 functiontypeof(m::Method) = parameter_typeof(m.sig)[1]
 parameter_typeof(sig::UnionAll) = parameter_typeof(sig.body)
 parameter_typeof(sig::DataType) = sig.parameters

--- a/src/method_utils.jl
+++ b/src/method_utils.jl
@@ -5,8 +5,7 @@ Returns the module associated with a method.
 Note: this is not the module where it was defined (m.module)
 but rather the module for which it's function was defined.
 """
-moduleof(m::Method) = functiontypeof(m).name.module
-
+moduleof(m) = functiontypeof(m).name.module
 functiontypeof(m::Method) = parameter_typeof(m.sig)[1]
 parameter_typeof(sig::UnionAll) = parameter_typeof(sig.body)
 parameter_typeof(sig::DataType) = sig.parameters
@@ -42,3 +41,5 @@ end
 
 # Builtin's do not have methods
 accepts(::Method, ::DispatchAttempt{<:Core.Builtin}) = false
+
+functiontypeof(m::DispatchAttempt{F}) where F = F

--- a/test/test_breakpoint_rules.jl
+++ b/test/test_breakpoint_rules.jl
@@ -4,7 +4,7 @@ using Test
 @testset "breakon rules" begin
     # Helper for defining rules during tests
     borule(args...) = BreakpointRules(Rule[], [Rule(args...)])
-    
+
     @testset "module" begin
         # I don't really think this is useful, but it does work
         rules = borule(Iterators)
@@ -22,7 +22,7 @@ using Test
             @test !should_breakon(rules, meth, 2)
         end
     end
-    
+
     @testset "Method" begin
         meths  = collect(methods(pwd))
         rules = borule(meths[1])
@@ -127,7 +127,7 @@ end
     @test should_instrument(rules, first(methods(sum)))
     @test !should_instrument(rules, first(methods(Iterators.flatten)))
     @test should_instrument(rules, first(methods(Iterators.drop)))
-    
+
 
     @test !should_breakon(rules, first(methods(+)), 0)
     @test !should_breakon(rules, first(methods(+)), 2)

--- a/test/test_breakpoint_rules.jl
+++ b/test/test_breakpoint_rules.jl
@@ -49,20 +49,16 @@ using Test
             @test !should_breakon(rules, meth, 2)
         end
     end
-
-
-
-
 end
 
 @testset "default" begin
     rules = BreakpointRules()
 
     # should instrument everything
-    @test should_instrument(rules, first(methods(+)))
-    @test should_instrument(rules, first(methods(sum)))
-    @test should_instrument(rules, first(methods(Iterators.flatten)))
-    @test should_instrument(rules, first(methods(Iterators.drop)))
+    @test should_instrument(rules, +)
+    @test should_instrument(rules, sum)
+    @test should_instrument(rules, Iterators.flatten)
+    @test should_instrument(rules, Iterators.drop)
 
     @test !should_breakon(rules, first(methods(+)), 0)
     @test !should_breakon(rules, first(methods(+)), 2)
@@ -79,10 +75,10 @@ end
         [Rule(Iterators)],
         []
     )
-    @test should_instrument(rules, first(methods(+)))
-    @test should_instrument(rules, first(methods(sum)))
-    @test !should_instrument(rules, first(methods(Iterators.flatten)))
-    @test !should_instrument(rules, first(methods(Iterators.drop)))
+    @test should_instrument(rules, +)
+    @test should_instrument(rules, sum)
+    @test !should_instrument(rules, Iterators.flatten)
+    @test !should_instrument(rules, Iterators.drop)
 
 
     @test !should_breakon(rules, first(methods(+)), 0)
@@ -102,11 +98,10 @@ end
         [Rule(Base)],
         []
     )
-    @test !should_instrument(rules, first(methods(+)))
-    @test !should_instrument(rules, first(methods(sum)))
-    @test should_instrument(rules, first(methods(Iterators.flatten)))
-    @test should_instrument(rules, first(methods(Iterators.drop)))
-
+    @test !should_instrument(rules, +)
+    @test !should_instrument(rules, sum)
+    @test should_instrument(rules, Iterators.flatten)
+    @test should_instrument(rules, Iterators.drop)
 
     @test !should_breakon(rules, first(methods(+)), 0)
     @test !should_breakon(rules, first(methods(+)), 2)
@@ -123,11 +118,10 @@ end
         [Rule(Iterators)],
         [Rule(Iterators.drop)]
     )
-    @test should_instrument(rules, first(methods(+)))
-    @test should_instrument(rules, first(methods(sum)))
-    @test !should_instrument(rules, first(methods(Iterators.flatten)))
-    @test should_instrument(rules, first(methods(Iterators.drop)))
-
+    @test should_instrument(rules, +)
+    @test should_instrument(rules, sum)
+    @test !should_instrument(rules, Iterators.flatten)
+    @test should_instrument(rules, Iterators.drop)
 
     @test !should_breakon(rules, first(methods(+)), 0)
     @test !should_breakon(rules, first(methods(+)), 2)
@@ -138,5 +132,3 @@ end
     @test should_breakon(rules, first(methods(Iterators.drop)), 0)
     @test !should_breakon(rules, first(methods(Iterators.drop)), 5)
 end
-
-

--- a/test/test_method_utils.jl
+++ b/test/test_method_utils.jl
@@ -16,6 +16,11 @@ Base.eps(::typeof(moduleof)) = "dummy"
     for meth in methods(eps)
         @test moduleof(meth) == Base
     end
+
+
+    for meth in methods(Vector)  # this is a UnionAll
+        @test moduleof(meth) == Core
+    end
 end
 
 

--- a/test/test_method_utils.jl
+++ b/test/test_method_utils.jl
@@ -1,9 +1,20 @@
 using Test
-using MagneticReadHead: moduleof, functiontypeof, methodof
+using InteractiveUtils
+using MagneticReadHead: moduleof, functiontypeof, DispatchAttempt, accepts
+
+
+# Define an extra method of eps in this module, so we can test methods of
+Base.eps(::typeof(moduleof)) = "dummy"
 
 @testset "moduleof" begin
     for meth in methods(detect_ambiguities)
         @test moduleof(meth) == Test
+    end
+
+    # We define a verion of eps in this module
+    # but we expect that it is still counted as being in `Base`
+    for meth in methods(eps)
+        @test moduleof(meth) == Base
     end
 end
 
@@ -20,33 +31,47 @@ end
     end
 end
 
-@testset "methodof" begin
+@testset "DispatchAttempt" begin
     @testset "BuiltIns" begin
-        @test methodof(Core.typeof) === nothing
-        @test methodof(Core.typeof, 1) === nothing
-    end
-
-    @testset "Ensure no errors" begin
-       @test methodof(+, 1, 1) isa Method
-       @test methodof(+, 2, 2.0) isa Method
-       @test methodof(+, 2.0, 2 + im) isa Method
-       
-       @test methodof(eps) isa Method
-       @test methodof(eps, Float32) isa Method
-    end
-
-    @testset "local function no args" begin
-        bar() = 1
-        @test functiontypeof(methodof(bar)) == typeof(bar)
-        @test moduleof(methodof(bar)) == @__MODULE__
+        meth_not = @which(!true)
+        @test accepts(meth_not, DispatchAttempt(Core.typeof, tuple())) === false
+        @test accepts(meth_not, DispatchAttempt(Core.typeof, (1,))) === false
     end
 
 
-    @testset "local function 1 arg" begin
-        foo(::Int) = 1
-        @test functiontypeof(methodof(foo, 20)) == typeof(foo)
-        @test moduleof(methodof(foo, 20)) == @__MODULE__
+    @testset "accepts" begin
+        function method_accepts(meth, f, args...)
+            da = DispatchAttempt(f, args)
+            return accepts(meth, da)
+        end
+        function check_accepts(f, args...)
+            default_meth = @which f(args...)
+            return method_accepts(default_meth, f, args...)
+        end
+
+        @test check_accepts(+, 1, 1)
+        @test check_accepts(+, 2, 2.0)
+        @test check_accepts(+, 2.0, 2 + im)
+        @test !method_accepts((@which 1+1), +, 'a', 'b')  # wrong method
+        @test !method_accepts((@which 1+1), *, 'a', 'b')  # wrong method
+
+        @test check_accepts(eps)  # No argument
+        @test check_accepts(eps, Float32)  #DataType as argument
+        @test !method_accepts((@which eps(Float32)), Int64) # wrong method
+
+        @testset "Constructor" begin
+            @test check_accepts(Int, true)
+            @test check_accepts(Int, 'c')
+            @test !method_accepts((@which Int(true)), 'c') # wrong method
+        end
+
+        @testset "Closure" begin
+            bar = 24
+            foo(x::Int) = x*bar
+            @test check_accepts(foo, 5)
+            @test !method_accepts((@which foo(5)), foo, 'c')
+        end
     end
 
-
+    
 end

--- a/test/test_method_utils.jl
+++ b/test/test_method_utils.jl
@@ -1,6 +1,6 @@
 using Test
 using InteractiveUtils
-using MagneticReadHead: moduleof, functiontypeof, DispatchAttempt, accepts
+using MagneticReadHead: moduleof, functiontypeof
 
 
 # Define an extra method of eps in this module, so we can test methods of
@@ -29,49 +29,4 @@ end
     for meth in methods(detect_ambiguities)
         @test functiontypeof(meth) <: typeof(detect_ambiguities)
     end
-end
-
-@testset "DispatchAttempt" begin
-    @testset "BuiltIns" begin
-        meth_not = @which(!true)
-        @test accepts(meth_not, DispatchAttempt(Core.typeof, tuple())) === false
-        @test accepts(meth_not, DispatchAttempt(Core.typeof, (1,))) === false
-    end
-
-
-    @testset "accepts" begin
-        function method_accepts(meth, f, args...)
-            da = DispatchAttempt(f, args)
-            return accepts(meth, da)
-        end
-        function check_accepts(f, args...)
-            default_meth = @which f(args...)
-            return method_accepts(default_meth, f, args...)
-        end
-
-        @test check_accepts(+, 1, 1)
-        @test check_accepts(+, 2, 2.0)
-        @test check_accepts(+, 2.0, 2 + im)
-        @test !method_accepts((@which 1+1), +, 'a', 'b')  # wrong method
-        @test !method_accepts((@which 1+1), *, 'a', 'b')  # wrong method
-
-        @test check_accepts(eps)  # No argument
-        @test check_accepts(eps, Float32)  #DataType as argument
-        @test !method_accepts((@which eps(Float32)), Int64) # wrong method
-
-        @testset "Constructor" begin
-            @test check_accepts(Int, true)
-            @test check_accepts(Int, 'c')
-            @test !method_accepts((@which Int(true)), 'c') # wrong method
-        end
-
-        @testset "Closure" begin
-            bar = 24
-            foo(x::Int) = x*bar
-            @test check_accepts(foo, 5)
-            @test !method_accepts((@which foo(5)), foo, 'c')
-        end
-    end
-
-    
 end

--- a/test/test_pass.jl
+++ b/test/test_pass.jl
@@ -14,7 +14,7 @@ using InteractiveUtils
     #@show ir
     #@show ir.codelocs
     errors = Core.Compiler.validate_code(ir)
-    @test_broken errors == []  # https://github.com/jrevels/Cassette.jl/pull/112
+    @test errors == []
     res = Cassette.recurse(ctx, Base._totuple, Tuple, 20)
     @test res == (20,)
 end

--- a/test/test_ui.jl
+++ b/test/test_ui.jl
@@ -31,6 +31,15 @@ clear_breakpoints!(); clear_nodebugs!()
 end
 
 ###################################################
+clear_breakpoints!(); clear_nodebugs!()
+@testset "No breakpoints, With no instrumenting of Base" begin
+    make_readline_patch([])
+    record = make_recording_breakpoint_hit_patch()
+    set_nodebug!(Base)
+    @iron_debug eg1()
+    @test record == []
+end
+###########################
 
 clear_breakpoints!(); clear_nodebugs!()
 @testset "breakpoint by file and linenum" begin


### PR DESCRIPTION
#27 
There is 1 key internal change of this, that should be invisible to users, more or less.
Rather than create a `Method` using `@which`, to decide if a method should be instrumented or not.
we instead query the function + argument against the set of rules.
Which is much faster, expectially in the case where no, or few `@no_debug` rules are set.
(as in the benchmark below).

**However, there is 1  problem with this.**
If you `set_nodebug` on a method, that takes fairly abstract arguments.
Then it will actually result in all more specific methods also being blocked.
I don't think that that is actually a serious usability issue.
As `set_nodebug` is mostly used ona function or module level.
 - One possible resolution is to just ban `set_nodebug` from working on a `method` level.
 - Another is to set make it legal but print a warning explaining its behavour.

A less problematic side effect of this change is that now setting no debug on a Module,
now takes out methods that belong to that module's functions, 
even when those methods are defined in other modules.
I do not think this change is a problem, as I think that is the more reasonable behavour to have.
It is about knocking out a whole namepace, not knocking out a particular package.

using the ["standard" summer test](https://gist.github.com/timholy/369c3fbf5d64ee09c3f9692e2db6c489)
for benchmarking debuggers:
(I have a feeling I am not using it the same way as in https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/204#issuecomment-478566966 though)


### With this PR:
```
julia> @btime @iron_debug summer($(ones(40)))
  4.238 ms (16043 allocations: 626.09 KiB)
40.0

julia> @btime @iron_debug summer_inlined($(ones(40)))
  2.312 ms (7956 allocations: 284.27 KiB)
40.0
```

### Current master:
```
julia> @btime @iron_debug summer($(ones(40)))
  9.792 ms (28160 allocations: 1.29 MiB)
40.0

julia> @btime @iron_debug summer_inlined($(ones(40)))
  3.545 ms (13097 allocations: 641.72 KiB)
40.0
```
