### PR TITLE
Use enum for stepping mode and do not create new context each time

### DIFF
--- a/src/MagneticReadHead.jl
+++ b/src/MagneticReadHead.jl
@@ -28,7 +28,7 @@ struct UserAbortedException <: Exception end
 
 macro iron_debug(body)
     quote
-        ctx = HandEvalCtx($(__module__), StepContinue())
+        ctx = HandEvalCtx($(__module__), StepContinue)
         try
             return Cassette.recurse(ctx, ()->$(esc(body)))
         catch err
@@ -36,7 +36,7 @@ macro iron_debug(body)
             nothing
         finally
             # Disable any stepping left-over
-            ctx.metadata.stepping_mode =  StepContinue()
+            ctx.metadata.stepping_mode =  StepContinue
         end
 
     end

--- a/src/break_action.jl
+++ b/src/break_action.jl
@@ -75,7 +75,7 @@ and if so open up a REPL.
 if not, then we continue.
 """
 function break_action(metadata, meth, statement_ind)
-    if !(metadata.stepping_mode isa StepNext
+    if !(metadata.stepping_mode === StepNext
          || should_breakon(metadata.breakpoint_rules, meth, statement_ind)
         )
         # Only break on StepNext and actual breakpoints

--- a/src/break_action.jl
+++ b/src/break_action.jl
@@ -1,4 +1,4 @@
-set_stepping_mode!(mode) = metadata->metadata.stepping_mode=mode()
+set_stepping_mode!(mode) = metadata->metadata.stepping_mode=mode
 const actions = OrderedDict([
    :CC => (desc="Continue",  act=set_stepping_mode!(StepContinue)),
    :SI => (desc="Step In",   act=set_stepping_mode!(StepIn)),

--- a/src/core_control.jl
+++ b/src/core_control.jl
@@ -1,25 +1,19 @@
 Cassette.@context HandEvalCtx
 
-abstract type SteppingMode end
-struct StepIn <: SteppingMode end
-struct StepNext <: SteppingMode end
-struct StepContinue <: SteppingMode end
-struct StepOut <: SteppingMode end
+@enum SteppingMode StepIn StepNext StepContinue StepOut
 
 
 # On the way in
-child_stepping_mode(ctx::HandEvalCtx) =  child_stepping_mode(ctx.metadata.stepping_mode)
-child_stepping_mode(::StepContinue) = StepContinue()
-child_stepping_mode(::StepNext) = StepContinue()  # contine over the function call
-child_stepping_mode(::StepIn) = StepNext()     # step within the function call
-child_stepping_mode(::StepOut) = StepContinue()  # Nothing is wanted not here not there
+@inline function child_stepping_mode!(ctx::HandEvalCtx)
+    cur_mode = ctx.metadata.stepping_mode
+    ctx.metadata.stepping_mode = cur_mode === StepIn ? StepNext : StepContinue
+end
 
 # On the way out
-parent_stepping_mode(ctx::HandEvalCtx) =  parent_stepping_mode(ctx.metadata.stepping_mode)
-parent_stepping_mode(::StepContinue) = StepContinue()
-parent_stepping_mode(::StepNext) = StepNext()  # Continue to next statement, which happens to be in parent
-parent_stepping_mode(::StepIn) = StepNext()  # can't go in, out will have to do
-parent_stepping_mode(::StepOut) = StepNext()   # This is what they want
+@inline function parent_stepping_mode!(ctx::HandEvalCtx)
+    cur_mode = ctx.metadata.stepping_mode
+    ctx.metadata.stepping_mode = cur_mode === StepContinue ? StepContinue : StepNext
+end
 
 
 mutable struct HandEvalMeta
@@ -41,7 +35,7 @@ function HandEvalMeta(eval_module, stepping_mode)
     )
 end
 
-function HandEvalCtx(eval_module, stepping_mode=StepContinue())
+function HandEvalCtx(eval_module, stepping_mode=StepContinue)
     ctx = HandEvalCtx(;metadata=HandEvalMeta(eval_module, stepping_mode), pass=handeval_pass)
     return Cassette.disablehooks(ctx)
 end
@@ -56,19 +50,19 @@ function Cassette.overdub(ctx::HandEvalCtx, f, @nospecialize(args...))
     # We control the flow of stepping modes
     # and which methods are instrumented or not.
     should_recurse =
-        ctx.metadata.stepping_mode isa StepIn ||
+        ctx.metadata.stepping_mode === StepIn ||
         should_instrument(ctx.metadata.breakpoint_rules, f)
 
     if should_recurse
         if Cassette.canrecurse(ctx, f, args...)
-            _ctx = HandEvalCtx(ctx.metadata.eval_module, child_stepping_mode(ctx))
+            child_stepping_mode!(ctx)
             try
                 return Cassette.recurse(_ctx, f, args...)
             finally
-                ctx.metadata.stepping_mode = parent_stepping_mode(_ctx)
+                parent_stepping_mode!(ctx)
             end
         else
-            @assert f isa Core.Builtin
+            #@assert f isa Core.Builtin
             #@warn "Not able to enter into method" f args
             return Cassette.fallback(ctx, f, args...)
         end

--- a/src/core_control.jl
+++ b/src/core_control.jl
@@ -56,10 +56,13 @@ function Cassette.overdub(ctx::HandEvalCtx, f, @nospecialize(args...))
     if should_recurse
         if Cassette.canrecurse(ctx, f, args...)
             child_stepping_mode!(ctx)
+            cur_variables = ctx.metadata.variables  # store these for after the call
+            ctx.metadata.variables = LittleDict{Symbol, Any}()
             try
-                return Cassette.recurse(_ctx, f, args...)
+                return Cassette.recurse(ctx, f, args...)
             finally
                 parent_stepping_mode!(ctx)
+                ctx.metadata.variables = cur_variables  # restore them
             end
         else
             #@assert f isa Core.Builtin


### PR DESCRIPTION
This is cut out of #48

It is a fair bit faster