### PR TITLE
test that we need to avoid isdefined before declared

### DIFF
--- a/test/test_pass.jl
+++ b/test/test_pass.jl
@@ -53,3 +53,25 @@ end
     end
 end
 
+
+@testset "let blocks in branches" begin
+    # this is the breaking case that means we need to check when variables come into scope
+
+    function danger11(x)
+        if x==1
+            y=1
+            return x
+        elseif x==2
+            let
+                m=2
+                x+=m
+            end
+            return 2x
+        end
+        return x
+    end
+
+    ctx = HandEvalCtx(@__MODULE__)
+    res = Cassette.recurse(ctx, danger11, 1)
+    @test res == 1
+end


### PR DESCRIPTION
This should have been in the commit that changed over to using `isdefined`,
it is the reason we hafve to workout when things were declared