### PR TITLE
Make @enter not go into the Debugger source.

### DIFF
--- a/src/MagneticReadHead.jl
+++ b/src/MagneticReadHead.jl
@@ -61,7 +61,7 @@ end
 Begin debugging and break on the start of the_code.
 """
 macro enter(body)
-    if body isa Expr && body.head==:call
+    if body isa Expr && body.head==:call && body.args[1] isa Symbol
         body = MacroTools.striplines(body)
         #break_target = body.args[1] #
         break_target = :(InteractiveUtils.which($(body.args[1]), Base.typesof($(body.args[2:end])...)))
@@ -78,12 +78,7 @@ macro enter(body)
         end
     else
         quote
-            @warn "Cannot identify function being `@enter`ed, engaging fallback mode"
-            ctx = HandEvalCtx($(__module__), StepContinue)
-            iron_debug(ctx) do
-                ctx.metadata.stepping_mode = StepIn
-                $(esc(body))
-            end
+            error("Expression too complex to `@enter`. Please use `@run` with manual breakpoint set")
         end
     end
 end

--- a/src/MagneticReadHead.jl
+++ b/src/MagneticReadHead.jl
@@ -63,7 +63,6 @@ Begin debugging and break on the start of the_code.
 macro enter(body)
     if body isa Expr && body.head==:call && body.args[1] isa Symbol
         body = MacroTools.striplines(body)
-        #break_target = body.args[1] #
         break_target = :(InteractiveUtils.which($(body.args[1]), Base.typesof($(body.args[2:end])...)))
         quote
             ctx = HandEvalCtx($(__module__), StepContinue)

--- a/src/breakpoints.jl
+++ b/src/breakpoints.jl
@@ -41,9 +41,9 @@ for (name, list) in ((:breakpoint, :breakon_rules), (:uninstrumented, :no_instru
     @eval function $(rm!)(the_rules::BreakpointRules, args...)
         old_num_rules = length(the_rules.$list)
         to_remove = rules(args...)
-        filter!(x->x∈to_remove, the_rules.$list)
+        filter!(!in(to_remove), the_rules.$list)
         if length(the_rules.$list) == old_num_rules
-            @info("No matching $($name) was found, so none removed")
+            @info("No matching rule was found, so none removed")
         end
         return the_rules.$list
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ test_files = (
     "test_behavour.jl",
     "test_breadcrumbs.jl",
     "test_breakpoint_rules.jl",
+    "test_breakpoints.jl",
     "test_inner_repl.jl",
     "test_locate.jl",
     "test_method_utils.jl",

--- a/test/test_breakpoints.jl
+++ b/test/test_breakpoints.jl
@@ -1,0 +1,10 @@
+using MagneticReadHead
+using Test
+
+@testset "Should be able to add and remove breakpoints" begin
+    @test length(set_breakpoint!(Test)) == 1
+    @test length(rm_breakpoint!(Test)) == 0
+
+    @test length(set_uninstrumented!(Test)) == 1
+    @test length(rm_uninstrumented!(Test)) == 0
+end

--- a/test/test_ui.jl
+++ b/test/test_ui.jl
@@ -86,6 +86,19 @@ clear_breakpoints!(); clear_uninstrumenteds!()
     @test first.(record) == [eg2, eg2, eg2]
 #end
 
+###############################################
+
+clear_breakpoints!(); clear_uninstrumenteds!()
+#@testset "@enter" begin
+    make_readline_patch(["CC"])
+    record = make_recording_breakpoint_hit_patch()
+
+    @enter eg1()
+    @test first.(record) == [eg1]
+    @test isempty(list_breakpoints())
+#end
+
+
 
 ###############################################
 clear_breakpoints!(); clear_uninstrumenteds!()

--- a/test/test_ui.jl
+++ b/test/test_ui.jl
@@ -98,6 +98,15 @@ clear_breakpoints!(); clear_uninstrumenteds!()
     @test isempty(list_breakpoints())
 #end
 
+clear_breakpoints!(); clear_uninstrumenteds!()
+#@testset "@enter, too complex" begin
+    make_readline_patch(["CC"])
+    record = make_recording_breakpoint_hit_patch()
+
+    @test_throws ErrorException (@enter (()->eg1())())
+    @test isempty(list_breakpoints())
+#end
+
 
 
 ###############################################


### PR DESCRIPTION
Closes #59  cc @KristofferC 
also fixes the fact that removing breakpoints never worked.
Adds tests for everything,.

Note #42  still occurs.

Also a side effect of this is that recursive functions will breakpoint everytime they hit the `@enter`ed method.
This can be avoided by running `rm _breakpoint` as approprate from the `debug>` prompt.
I guess the real solution would be to add a special kind of breakpoint that can only be hit once or something.
