### PR TITLE
Don't store Stepping State or Breakpoint Rules in the context

### DIFF
--- a/src/MagneticReadHead.jl
+++ b/src/MagneticReadHead.jl
@@ -37,7 +37,7 @@ function iron_debug(debugbody, ctx)
         nothing
     finally
         # Disable any stepping left-over
-        ctx.metadata.stepping_mode =  StepContinue
+        GLOBAL_STEPPING_MODE[] =  StepContinue
     end
 end
 
@@ -47,7 +47,7 @@ Run until the_code until a breakpoint is hit.
 """
 macro run(body)
     quote
-        ctx = HandEvalCtx($(__module__), StepContinue)
+        ctx = HandEvalCtx($(__module__))
         iron_debug(ctx) do
             $(esc(body))
         end
@@ -65,7 +65,7 @@ macro enter(body)
         body = MacroTools.striplines(body)
         break_target = :(InteractiveUtils.which($(body.args[1]), Base.typesof($(body.args[2:end])...)))
         quote
-            ctx = HandEvalCtx($(__module__), StepContinue)
+            ctx = HandEvalCtx($(__module__))
             set_breakpoint!($(esc(break_target)))
             try
                 iron_debug(ctx) do

--- a/src/MagneticReadHead.jl
+++ b/src/MagneticReadHead.jl
@@ -31,7 +31,7 @@ struct UserAbortedException <: Exception end
 
 function iron_debug(debugbody)
     try
-        ctx = HandEvalCtx()
+        ctx = new_debug_ctx()
         return Cassette.recurse(ctx, debugbody)
     catch err
         err isa UserAbortedException || rethrow()

--- a/src/break_action.jl
+++ b/src/break_action.jl
@@ -54,14 +54,14 @@ end
 # this function exists only for mocking so we can test it.
 breakpoint_hit(meth, statement_ind, variables) = nothing
 
-function iron_repl(metadata::HandEvalMeta, meth, statement_ind, variables)
+function iron_repl(meth, statement_ind, variables)
     breadcrumbs(meth, statement_ind)
 
     printstyled("Vars: "; color=:light_yellow)
     println(join(keys(variables), ", "))
     print_commands()
 
-    run_repl(variables, metadata.eval_module)
+    run_repl(variables, Main)
 end
 
 """
@@ -79,13 +79,12 @@ end
 
 What to do when a breakpoint is hit
 """
-function break_action(ctx, meth, statement_ind, slotnames, slotvals)
-    metadata = ctx.metadata
+function break_action(meth, statement_ind, slotnames, slotvals)
 
     variables = LittleDict(slotnames, slotvals)
     pop!(variables, Symbol("#self#"))
     breakpoint_hit(meth, statement_ind, variables)
 
-    code_word = iron_repl(metadata, meth, statement_ind, variables)
+    code_word = iron_repl(meth, statement_ind, variables)
     actions[code_word].act()
 end

--- a/src/break_action.jl
+++ b/src/break_action.jl
@@ -1,10 +1,10 @@
-set_stepping_mode!(mode) = metadata->metadata.stepping_mode=mode
+set_stepping_mode!(mode) = ()->GLOBAL_STEPPING_MODE[]=mode
 const actions = OrderedDict([
    :CC => (desc="Continue",  act=set_stepping_mode!(StepContinue)),
    :SI => (desc="Step In",   act=set_stepping_mode!(StepIn)),
    :SN => (desc="Step Next", act=set_stepping_mode!(StepNext)),
    :SO => (desc="Step Out",  act=set_stepping_mode!(StepOut)),
-   :XX => (desc="Abort",     act=metadata->throw(UserAbortedException())),
+   :XX => (desc="Abort",     act=()->throw(UserAbortedException())),
 ])
 
 function print_commands()
@@ -87,5 +87,5 @@ function break_action(ctx, meth, statement_ind, slotnames, slotvals)
     breakpoint_hit(meth, statement_ind, variables)
 
     code_word = iron_repl(metadata, meth, statement_ind, variables)
-    actions[code_word].act(metadata)
+    actions[code_word].act()
 end

--- a/src/break_action.jl
+++ b/src/break_action.jl
@@ -68,9 +68,9 @@ end
     should_break
 Determines if we should actualy break at a potential breakpoint
 """
-function should_break(ctx, meth, statement_ind)
-    return ctx.metadata.stepping_mode === StepNext ||
-        should_breakon(ctx.metadata.breakpoint_rules, meth, statement_ind)
+function should_break(meth, statement_ind)
+    return GLOBAL_STEPPING_MODE[] === StepNext ||
+        should_breakon(GLOBAL_BREAKPOINT_RULES, meth, statement_ind)
 end
 
 

--- a/src/core_control.jl
+++ b/src/core_control.jl
@@ -5,15 +5,16 @@ Cassette.@context HandEvalCtx
 const GLOBAL_BREAKPOINT_RULES = BreakpointRules()
 const GLOBAL_STEPPING_MODE = Ref(StepContinue)
 
-function HandEvalCtx()
+
+"""
+    new_debug_ctx()::HandEvalCtx
+creates a debug context, with the pass set
+and extranious hooks disabled.
+"""
+function new_debug_ctx()
     ctx = HandEvalCtx(;pass=handeval_pass)
     return Cassette.disablehooks(ctx)
 end
-
-function Cassette.overdub(::typeof(HandEvalCtx()), args...)
-    error("HandEvalCtx without any had an overdub called on it. This should never happen as HandEvalCtx should never be constructed without giving them their metadata.")
-end
-
 
 @inline function Cassette.overdub(ctx::HandEvalCtx, f, args...)
     # This is basically the epicenter of all the logic

--- a/src/core_control.jl
+++ b/src/core_control.jl
@@ -5,13 +5,8 @@ Cassette.@context HandEvalCtx
 const GLOBAL_BREAKPOINT_RULES = BreakpointRules()
 const GLOBAL_STEPPING_MODE = Ref(StepContinue)
 
-
-mutable struct HandEvalMeta
-    eval_module::Module
-end
-
-function HandEvalCtx(eval_module)
-    ctx = HandEvalCtx(;metadata=HandEvalMeta(eval_module), pass=handeval_pass)
+function HandEvalCtx()
+    ctx = HandEvalCtx(;pass=handeval_pass)
     return Cassette.disablehooks(ctx)
 end
 

--- a/src/pass.jl
+++ b/src/pass.jl
@@ -122,7 +122,7 @@ function enter_debug_statements(
     )
     
     statements = [
-        call_expr(MagneticReadHead, :should_break, Expr(:contextslot), method, orig_ind),
+        call_expr(MagneticReadHead, :should_break, method, orig_ind),
         Expr(:REPLACE_THIS_WITH_GOTOIFNOT_AT_END),
         call_expr(Base, :getindex, GlobalRef(Core, :Symbol)),
         call_expr(Base, :getindex, GlobalRef(Core, :Any)),

--- a/src/pass.jl
+++ b/src/pass.jl
@@ -128,7 +128,7 @@ function enter_debug_statements(
         call_expr(Base, :getindex, GlobalRef(Core, :Any)),
     ]
     stop_cond_ssa = Core.SSAValue(ind)
-    # Skip the pplaceholder
+    # Skip the placeholder
     names_ssa = Core.SSAValue(ind + 2)
     values_ssa = Core.SSAValue(ind + 3)
     cur_ind = ind + 4
@@ -148,7 +148,6 @@ function enter_debug_statements(
 
     push!(statements, call_expr(
         MagneticReadHead, :break_action,
-        Expr(:contextslot),
         method,
         orig_ind,
         names_ssa, values_ssa)

--- a/test/test_pass.jl
+++ b/test/test_pass.jl
@@ -1,6 +1,6 @@
 
 using MagneticReadHead
-using MagneticReadHead: HandEvalCtx, handeval_pass
+using MagneticReadHead: new_debug_ctx
 using Cassette
 using Test
 
@@ -9,7 +9,7 @@ using InteractiveUtils
 # This test we are keeping around just to demonstrate how to
 # check on when things go wrong
 @testset "_totuple" begin
-    ctx = HandEvalCtx()
+    ctx = new_debug_ctx()
     ir = @code_lowered Cassette.recurse(ctx, Base._totuple, Tuple, 20)
     #@show ir
     #@show ir.codelocs
@@ -27,7 +27,7 @@ end
         (fn = Base._totuple, args=(Tuple, 41)),
     )
     for code in normal_codes
-        ctx = HandEvalCtx()
+        ctx = new_debug_ctx()
         expected = code.fn(code.args...)
         direct_recurse = Cassette.recurse(ctx, code.fn, code.args...)
         @test expected == direct_recurse
@@ -42,12 +42,12 @@ function boopa!(x,y)
 end
 
 @testset "basic mutating function" begin
-    ctx = HandEvalCtx()
+    ctx = new_debug_ctx()
     res = Cassette.recurse(ctx, boopa!, [1,2], 3)
     @test res == [3,2]
 
     @testset "function calling a basic mutating function" begin
-        ctx = HandEvalCtx()
+        ctx = new_debug_ctx()
         res = Cassette.recurse(ctx, ()->boopa!([1,2],4))
         @test res == [4,2]
     end
@@ -71,7 +71,7 @@ end
         return x
     end
 
-    ctx = HandEvalCtx()
+    ctx = new_debug_ctx()
     res = Cassette.recurse(ctx, danger11, 1)
     @test res == 1
 end
@@ -87,7 +87,7 @@ end
         inner()
     end
 
-    ctx = HandEvalCtx()
+    ctx = new_debug_ctx()
     res = Cassette.recurse(ctx, danger19)
     @test res == 2
 end

--- a/test/test_pass.jl
+++ b/test/test_pass.jl
@@ -9,7 +9,7 @@ using InteractiveUtils
 # This test we are keeping around just to demonstrate how to
 # check on when things go wrong
 @testset "_totuple" begin
-    ctx = HandEvalCtx(@__MODULE__)
+    ctx = HandEvalCtx()
     ir = @code_lowered Cassette.recurse(ctx, Base._totuple, Tuple, 20)
     #@show ir
     #@show ir.codelocs
@@ -27,7 +27,7 @@ end
         (fn = Base._totuple, args=(Tuple, 41)),
     )
     for code in normal_codes
-        ctx = HandEvalCtx(@__MODULE__)
+        ctx = HandEvalCtx()
         expected = code.fn(code.args...)
         direct_recurse = Cassette.recurse(ctx, code.fn, code.args...)
         @test expected == direct_recurse
@@ -42,12 +42,12 @@ function boopa!(x,y)
 end
 
 @testset "basic mutating function" begin
-    ctx = HandEvalCtx(@__MODULE__)
+    ctx = HandEvalCtx()
     res = Cassette.recurse(ctx, boopa!, [1,2], 3)
     @test res == [3,2]
 
     @testset "function calling a basic mutating function" begin
-        ctx = HandEvalCtx(@__MODULE__)
+        ctx = HandEvalCtx()
         res = Cassette.recurse(ctx, ()->boopa!([1,2],4))
         @test res == [4,2]
     end
@@ -71,7 +71,7 @@ end
         return x
     end
 
-    ctx = HandEvalCtx(@__MODULE__)
+    ctx = HandEvalCtx()
     res = Cassette.recurse(ctx, danger11, 1)
     @test res == 1
 end
@@ -87,7 +87,7 @@ end
         inner()
     end
 
-    ctx = HandEvalCtx(@__MODULE__)
+    ctx = HandEvalCtx()
     res = Cassette.recurse(ctx, danger19)
     @test res == 2
 end


### PR DESCRIPTION
I had hoped this would help with #56, for reasons.
It did not.

But I was planning on doing this anyway as at some point I intend to switch over to IRTools.
and IRTools doesn't have the notion coresponding to Cassette's context.

Turns out (as I suspected) this does not have any performance impact.
Infact it gives a 5% speedup (and 200bytes less allocations)

### Before:
```
julia> @btime @run summer($(rand(4000)))
  8.950 ms (36948 allocations: 827.42 KiB)
2005.1816094488515

julia> @btime @run summer($(rand(4000)))
  9.070 ms (36948 allocations: 827.42 KiB)
2003.61408723352

julia> @btime @run summer($(rand(4000)))
  9.019 ms (36948 allocations: 827.42 KiB)
2004.4255763210997
```


### After
```
julia> @btime @run summer($(rand(4000)))
  8.364 ms (36948 allocations: 827.41 KiB)
2000.0012459445081

julia> @btime @run summer($(rand(4000)))
  8.502 ms (36948 allocations: 827.41 KiB)
2014.4012688708347

julia> @btime @run summer($(rand(4000)))
  8.262 ms (36948 allocations: 827.41 KiB)
1997.3189807056297
```