### PR TITLE
[WIP] Improve compile times

### DIFF
--- a/src/break_action.jl
+++ b/src/break_action.jl
@@ -80,11 +80,14 @@ end
 What to do when a breakpoint is hit
 """
 function break_action(meth, statement_ind, slotnames, slotvals)
+   variables = LittleDict(
+      name=>val
+      for (name,val) in zip(slotnames, slotvals)
+         if val!==VariableNotDefined()
+   )
 
-    variables = LittleDict(slotnames, slotvals)
-    pop!(variables, Symbol("#self#"))
-    breakpoint_hit(meth, statement_ind, variables)
+   breakpoint_hit(meth, statement_ind, variables)
 
-    code_word = iron_repl(meth, statement_ind, variables)
-    actions[code_word].act()
+   code_word = iron_repl(meth, statement_ind, variables)
+   actions[code_word].act()
 end

--- a/src/pass.jl
+++ b/src/pass.jl
@@ -69,7 +69,9 @@ function created_on(reflection)
     created_stmt_ind = fill(typemax(Int), length(ir.slotnames))
     banned = falses(length(ir.slotnames))
 
-    # #self# and all the arguments are created at start
+    banned[1] = true  # Don't need #self
+
+    # all the arguments are created at start
     nargs = reflection.method.nargs
     if nargs > length(created_stmt_ind)
         error("More arguments than slots")

--- a/src/pass.jl
+++ b/src/pass.jl
@@ -200,7 +200,11 @@ function instrument!(::Type{<:HandEvalCtx}, reflection::Cassette.Reflection)
     slot_created_ons = created_on(reflection)
     extended_insert_statements!(
         ir.code, ir.codelocs,
-        (stmt, i) -> stmt isa Expr ? enter_debug_statements_count(slot_created_ons, i) : nothing,
+        (stmt, ii) -> begin
+            stmt isa Expr || return nothing
+            ii>1 && @inbounds(ir.codelocs[ii]==ir.codelocs[ii-1]) && return nothing
+            return enter_debug_statements_count(slot_created_ons, ii)
+        end,
         (stmt, i, orig_i) -> enter_debug_statements(
             ir.slotnames, slot_created_ons, reflection.method,
             stmt, i, orig_i

--- a/src/pass.jl
+++ b/src/pass.jl
@@ -31,7 +31,7 @@ function extended_insert_statements!(code, codelocs, stmtcount, newstmts)
     ssachangemap = fill(0, length(code))
     labelchangemap = fill(0, length(code))
     worklist = Tuple{Int,Int}[]
-    for i in 1:length(code)
+    @inbounds for i in 1:length(code)
         stmt = code[i]
         nstmts = stmtcount(stmt, i)
         if nstmts !== nothing
@@ -44,7 +44,7 @@ function extended_insert_statements!(code, codelocs, stmtcount, newstmts)
         end
     end
     Core.Compiler.renumber_ir_elements!(code, ssachangemap, labelchangemap)
-    for (src_i, addedstmts) in worklist
+    @inbounds for (src_i, addedstmts) in worklist
         dest_i = src_i + ssachangemap[src_i] - addedstmts # correct the index for accumulated offsets
         stmts = newstmts(code[dest_i], dest_i, src_i)
         @assert(length(stmts) == (addedstmts + 1), "$(length(stmts)) == $(addedstmts + 1)")
@@ -61,7 +61,7 @@ end
 Given an `Cassette.Reflection` returns a vector the same length as slotnames,
 which each entry is the ir statment index for where the coresponding variable was delcared
 """
-function created_on(reflection)
+@inline function created_on(reflection)
     # This is a simplification of
     # https://github.com/JuliaLang/julia/blob/236df47251c203c71abd0604f2f19bf1f9c639fd/base/compiler/ssair/slot2ssa.jl#L47
     
@@ -128,7 +128,7 @@ show the debugging prompt.
  - ind: the actual index in the code IR this is being  inserted at. This is where the SSAValues start from
  - orig_ind: the index in the original code IR for where this is being inserted. (before other debug statements were inserted above)
 """
-function enter_debug_statements(
+@inline function enter_debug_statements(
     slotnames, slot_created_ons, method::Method,
     stmt, ind::Int, orig_ind::Int
     )
@@ -194,7 +194,7 @@ end
 This is the transform for the debugger cassette pass.
 it is the main method of this file, and calls all the ones defined earlier.
 """
-function instrument!(::Type{<:HandEvalCtx}, reflection::Cassette.Reflection)
+@inline function instrument!(::Type{<:HandEvalCtx}, reflection::Cassette.Reflection)
     ir = reflection.code_info
 
     slot_created_ons = created_on(reflection)

--- a/test/test_ui.jl
+++ b/test/test_ui.jl
@@ -136,6 +136,7 @@ function var_demo1(x)
     z=2x
     y=z
     z=1
+    return 0
 end
 
 clear_breakpoints!(); clear_uninstrumenteds!()


### PR DESCRIPTION
This incorperate s #68 

Main improvement so far is to add 1 less statement per slot, but not building names again

### TODO:
- [ ] Introduce new sentinel value (rather than nothing) for Undefined/unassigned
- [ ] make break_action/debug repl respect it 

##benchmarks
Each timing the follows was run in an new julia session
```
# Ban only
julia> @time @run(summer([1,2,3]))
 14.896919 seconds (78.02 M allocations: 3.022 GiB, 10.86% gc time)
6

# Ban + first use
julia> @time @run(summer([1,2,3]))
 15.061849 seconds (77.96 M allocations: 3.023 GiB, 11.72% gc time)
6

# Don't build name list
julia> @time @run(summer([1,2,3]))
  9.147239 seconds (48.24 M allocations: 1.984 GiB, 11.80% gc time)
6
```