### PR TITLE
Use compiler tools to workout what is defined where

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,10 +16,13 @@ Cassette = "0.2.2"
 CodeTracking = "0.5.0"
 OrderedCollections = "1.1"
 Revise = "2.1.3"
+TimerOutputs = "~0.5.0"
 julia = "1.1"
+
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [targets]
 test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -25,4 +25,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [targets]
-test = ["Test"]
+test = ["Test", "TimerOutputs"]

--- a/src/break_action.jl
+++ b/src/break_action.jl
@@ -80,12 +80,7 @@ end
 What to do when a breakpoint is hit
 """
 function break_action(meth, statement_ind, slotnames, slotvals)
-   variables = LittleDict(
-      name=>val
-      for (name,val) in zip(slotnames, slotvals)
-         if val!==VariableNotDefined()
-   )
-
+   variables = LittleDict(slotnames, slotvals)
    breakpoint_hit(meth, statement_ind, variables)
 
    code_word = iron_repl(meth, statement_ind, variables)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using Revise: Revise
 using MagneticReadHead
 using Test
 
+using TimerOutputs: TimerOutputs
+
 test_files = (
     "test_behavour.jl",
     "test_breadcrumbs.jl",

--- a/test/test_pass.jl
+++ b/test/test_pass.jl
@@ -91,3 +91,11 @@ end
     res = Cassette.recurse(ctx, danger19)
     @test res == 2
 end
+
+@testset "TimerOutputs based breaking case" begin
+    # This is the case from https://github.com/oxinabox/MagneticReadHead.jl/issues/56
+    # if that was not fixed then the `@run` line will cause errors
+    iob = IOBuffer()
+    @run TimerOutputs.print_header(iob, 0.5, 0.1, 3, 3, 7, false, true, 11, true, "oio")
+    @test !isempty(String(take!(iob)))
+end


### PR DESCRIPTION
Actionizes #73 
This is branching off #70 
In theory this should improve compile-times.
Though it is a fiddly trade-off.
We are doing more work to hopefully do less work.

Right now: first run;
```
@time @run summer((rand(4000)));
 16.506276 seconds (72.55 M allocations: 3.264 GiB, 7.98% gc time)
```

Note that on #70 we have
```
  7.521864 seconds (40.63 M allocations: 1.658 GiB, 10.85% gc time)
```


And with this PR
```
julia> @time @run TimerOutputs.print_header(stdout, 0.5, 0.1, 3, 3, 7, false, true, 11, true, "oio")
 146.131464 seconds (584.86 M allocations: 24.376 GiB, 11.01% gc time)
```

With just #70 
```
julia> @time @run TimerOutputs.print_header(stdout, 0.5, 0.1, 3, 3, 7, false, true, 11, true, "oio")
 -----------------------------------------------
 130.389314 seconds (449.39 M allocations: 17.303 GiB, 10.31% gc time)
```